### PR TITLE
docs(contribution): added missing generateBase64 import

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,8 +201,8 @@ export function generate(schema: Schema): Template {
 
   const mounts: Template["mounts"] = [
     {
-      mountPath: "./clickhouse/clickhouse-config.xml",
-      content: `some content......`,
+      filePath: "./clickhouse/clickhouse-config.xml",
+      content: "some content......",
     },
   ];
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,6 +169,7 @@ Let's take the example of `plausible` template.
 ```typescript
 // EXAMPLE
 import {
+  generateBase64,
   generateHash,
   generateRandomDomain,
   type Template,


### PR DESCRIPTION
See https://github.com/nktnet1/dokploy/blob/332416b7e7d9ceb740dc67a22302e74deb9f1205/CONTRIBUTING.md?plain=1#L171-L183

`generateBase64` is being used without being imported from `"../utils"`